### PR TITLE
Implement shuffle and refresh controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,6 +1119,7 @@ dependencies = [
  "image 0.25.6",
  "log",
  "notify",
+ "rand",
  "serde",
  "tokio",
  "wgpu 26.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ notify = { version = "8.1.0", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "serde_derive"] }
 tokio = { version = "1.46.1", features = ["full"] }
 wgpu = "26.0.1"
+rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Welcome to the **Picture Gallery App**! 🎨 This vibrant and responsive app is 
 
 ### 🔄 **Image Shuffle**
 
-* [ ] Shuffle images randomly in real-time.
+* [x] Shuffle images randomly in real-time.
 * [ ] Customizable shuffle intervals and speeds.
 
 ### 🖼️ **Grid Collages**
@@ -94,8 +94,8 @@ cargo run
 
 ### 🚩 **Phase 3: Shuffle & Refresh**
 
-* [ ] Randomized shuffle functionality
-* [ ] Independent image refresh mechanism
+* [x] Randomized shuffle functionality
+* [x] Independent image refresh mechanism
 
 ### 🚩 **Phase 4: UI & Styling**
 
@@ -181,3 +181,4 @@ Encounter an issue or have suggestions? Open an issue on GitHub! 🚀
 - **2025-07-19** Implemented grid layout for multiple images.
 - **2025-07-19** Added .gitignore rules to exclude binary images.
 - **2025-07-19** Added dynamic grid controls and image refresh timer.
+- **2025-07-19** Implemented shuffle and refresh buttons with independent image refresh.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,12 +63,13 @@ The third phase focuses on shuffling the images in the grid and ensuring that ea
 ### **3.1 Implement Shuffle Function**
 
 * [ ] **Shuffle the images** in the grid randomly when triggered.
-* [ ] **Add shuffle button** to trigger the image shuffling.
+* [x] **Shuffle the images** in the grid randomly when triggered.
+* [x] **Add shuffle button** to trigger the image shuffling.
 
 ### **3.2 Implement Refresh Mechanism**
 
-* [ ] **Add refresh button** to refresh the grid (reload images).
-* [ ] **Make sure images refresh independently at their set rates**.
+* [x] **Add refresh button** to refresh the grid (reload images).
+* [x] **Make sure images refresh independently at their set rates**.
 
 ---
 
@@ -147,4 +148,5 @@ By following this roadmap, you'll be able to track progress effectively and focu
 - **2025-07-19** Implemented grid layout for multiple images.
 - **2025-07-19** Added .gitignore rules to exclude binary images.
 - **2025-07-19** Completed Phase 2 dynamic grid and refresh logic.
+- **2025-07-19** Implemented shuffle and refresh controls for Phase 3.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ mod model;
 mod view;
 
 use env_logger::Env;
+use iced::{Element, application, time};
 use log::info;
-use iced::{application, time, Element};
 use model::Model;
 use view::create_collage_viewer;
 
@@ -11,6 +11,8 @@ use view::create_collage_viewer;
 enum Message {
     IncreaseGrid,
     DecreaseGrid,
+    Shuffle,
+    Refresh,
     Tick,
 }
 
@@ -37,8 +39,14 @@ fn update(state: &mut State, message: Message) {
                 state.model.update_grid_size(state.model.grid_size - 1);
             }
         }
+        Message::Shuffle => {
+            state.model.shuffle_images();
+        }
+        Message::Refresh => {
+            state.model.force_refresh();
+        }
         Message::Tick => {
-            state.model.refresh();
+            state.model.refresh_due_images();
         }
     }
 }
@@ -49,6 +57,8 @@ fn view(state: &State) -> Element<Message> {
         state.model.grid_size,
         Message::IncreaseGrid,
         Message::DecreaseGrid,
+        Message::Shuffle,
+        Message::Refresh,
     )
     .into()
 }
@@ -57,8 +67,6 @@ fn main() -> iced::Result {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
     info!("Launching Iced Gallery App");
     application("Iced Gallery App", update, view)
-        .subscription(|state: &State| {
-            time::every(state.model.refresh_rate).map(|_| Message::Tick)
-        })
+        .subscription(|state: &State| time::every(state.model.refresh_rate).map(|_| Message::Tick))
         .run()
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,20 +1,22 @@
-use iced::widget::{Button, Column, Image, Row, Text};
 use iced::Length;
+use iced::widget::{Button, Column, Image, Row, Text};
 
 pub fn create_collage_viewer<Message: Clone + 'static>(
     grid: &[String],
     grid_size: usize,
     inc_msg: Message,
     dec_msg: Message,
+    shuffle_msg: Message,
+    refresh_msg: Message,
 ) -> Column<'static, Message> {
     let mut column = Column::new().spacing(10);
 
     let controls = Row::new()
         .spacing(5)
-        .push(Button::new(Text::new("-"))
-            .on_press(dec_msg))
-        .push(Button::new(Text::new("+"))
-            .on_press(inc_msg));
+        .push(Button::new(Text::new("-")).on_press(dec_msg))
+        .push(Button::new(Text::new("+")).on_press(inc_msg))
+        .push(Button::new(Text::new("Shuffle")).on_press(shuffle_msg))
+        .push(Button::new(Text::new("Refresh")).on_press(refresh_msg));
 
     column = column.push(controls);
     for row_index in 0..grid_size {


### PR DESCRIPTION
## Summary
- add `rand` dependency for shuffle support
- implement per-cell refresh handling and shuffle logic
- expose Shuffle and Refresh messages and buttons
- mark completed roadmap tasks for Phase 3
- document AI activity in roadmap and README

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687b7f7c31c48332b24d678ba313ad33