### PR TITLE
Enable X11 backend for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Welcome to the **Picture Gallery App**! 🎨 This vibrant and responsive app is 
 * Notify **5.0** (optional folder monitoring)
 * Image **0.24** (image manipulation)
 * wgpu **0.12** (optional GPU effects)
+* X11 libraries (**Linux only**) to support the display backend
 
 ### 🔧 **Installation**
 
@@ -74,7 +75,7 @@ Run your app:
 
 ```bash
 cargo build
-cargo run
+WINIT_UNIX_BACKEND=x11 cargo run
 ```
 
 ---
@@ -131,7 +132,7 @@ These are exciting features planned beyond the current roadmap:
 
 ## 🌐 **Platform**
 
-* Currently supports **Linux**.
+* Currently supports **Linux** using the **X11** backend.
 * Future support for **Windows**, **macOS**, and **Web** planned.
 
 ---
@@ -184,3 +185,4 @@ Encounter an issue or have suggestions? Open an issue on GitHub! 🚀
 - **2025-07-19** Added dynamic grid controls and image refresh timer.
 - **2025-07-19** Implemented shuffle and refresh buttons with independent image refresh.
 - **2025-07-19** Added themed UI with customizable cell sizes.
+- **2025-07-19** Configured X11 backend on Linux and updated docs.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@ This phase will cover the basic foundation of the app, ensuring that the app com
   * `Iced` (UI framework)
   * `log` (for logging and debugging)
   * `image` (for image manipulation)
+  * `X11` libraries for Linux display support
 * [x] **Set up a new Rust project**.
 * [x] **Implement logging setup** using `env_logger`.
 
@@ -150,4 +151,5 @@ By following this roadmap, you'll be able to track progress effectively and focu
 - **2025-07-19** Completed Phase 2 dynamic grid and refresh logic.
 - **2025-07-19** Implemented shuffle and refresh controls for Phase 3.
 - **2025-07-19** Completed Phase 4 UI customization and theming.
+- **2025-07-19** Enabled X11 backend configuration for Linux.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,10 @@ fn view(state: &State) -> Element<Message> {
 
 fn main() -> iced::Result {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+    #[cfg(target_os = "linux")]
+    unsafe {
+        std::env::set_var("WINIT_UNIX_BACKEND", "x11");
+    }
     info!("Launching Iced Gallery App");
     application("Iced Gallery App", update, view)
         .theme(|state: &State| state.theme.clone())


### PR DESCRIPTION
## Summary
- configure app to use X11 backend on Linux via `WINIT_UNIX_BACKEND`
- document X11 requirement in README
- log X11 setup in roadmap and README

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687bb04a7e388332819f1e767cb61f5f